### PR TITLE
Migrating build check from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,26 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Test with pytest
+        run: |
+          pip install pytest pytest-cov
+          python -m pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-  - &mainstream_python 3.9
-cache: pip
-script:
-  - python -m pytest -v

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ and `LilyPond`_.
    :target: https://github.com/gilbertohasnofb/auxjad
 .. |PyPI| image:: https://img.shields.io/pypi/v/auxjad.svg?style=for-the-badge
    :target: https://pypi.python.org/pypi/auxjad
-.. |Build| image:: https://img.shields.io/travis/gilbertohasnofb/auxjad?style=for-the-badge
-   :target: https://app.travis-ci.com/gilbertohasnofb/auxjad
+.. |Build| image:: https://img.shields.io/github/actions/workflow/status/gilbertohasnofb/auxjad/github-actions.yml
+   :target: https://github.com/gilbertohasnofb/auxjad/actions/workflows/github-actions.yml
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/auxjad.svg?style=for-the-badge
    :target: https://www.python.org/downloads/release/python-390/
 .. |License| image:: https://img.shields.io/badge/license-MIT-blue?style=for-the-badge

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ and `LilyPond`_.
    :target: https://github.com/gilbertohasnofb/auxjad
 .. |PyPI| image:: https://img.shields.io/pypi/v/auxjad.svg?style=for-the-badge
    :target: https://pypi.python.org/pypi/auxjad
-.. |Build| image:: https://img.shields.io/github/actions/workflow/status/gilbertohasnofb/auxjad/github-actions.yml
+.. |Build| image:: https://img.shields.io/github/actions/workflow/status/gilbertohasnofb/auxjad/github-actions.yml?style=for-the-badge
    :target: https://github.com/gilbertohasnofb/auxjad/actions/workflows/github-actions.yml
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/auxjad.svg?style=for-the-badge
    :target: https://www.python.org/downloads/release/python-390/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,8 +70,8 @@ Each member of this library is individually documented in the `Auxjad API`_ page
    :target: https://github.com/gilbertohasnofb/auxjad
 .. |PyPI| image:: https://img.shields.io/pypi/v/auxjad.svg?style=for-the-badge
    :target: https://pypi.python.org/pypi/auxjad
-.. |Build| image:: https://img.shields.io/travis/gilbertohasnofb/auxjad?style=for-the-badge
-   :target: https://app.travis-ci.com/gilbertohasnofb/auxjad
+.. |Build| image:: https://img.shields.io/github/actions/workflow/status/gilbertohasnofb/auxjad/github-actions.yml
+   :target: https://github.com/gilbertohasnofb/auxjad/actions/workflows/github-actions.yml
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/auxjad.svg?style=for-the-badge
    :target: https://www.python.org/downloads/release/python-390/
 .. |License| image:: https://img.shields.io/badge/license-MIT-blue?style=for-the-badge

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,7 +71,7 @@ Each member of this library is individually documented in the `Auxjad API`_ page
 .. |PyPI| image:: https://img.shields.io/pypi/v/auxjad.svg?style=for-the-badge
    :target: https://pypi.python.org/pypi/auxjad
 .. |Build| image:: https://img.shields.io/github/actions/workflow/status/gilbertohasnofb/auxjad/github-actions.yml
-   :target: https://github.com/gilbertohasnofb/auxjad/actions/workflows/github-actions.yml
+   :target: https://github.com/gilbertohasnofb/auxjad/actions/workflows/github-actions.yml?style=for-the-badge
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/auxjad.svg?style=for-the-badge
    :target: https://www.python.org/downloads/release/python-390/
 .. |License| image:: https://img.shields.io/badge/license-MIT-blue?style=for-the-badge


### PR DESCRIPTION
Currently, build badge in the repository and docs are broken due to Travis CI not building any longer. Migrating to GitHub Actions as a result.