### PR TITLE
unit tests dont need mandatory docstrings enforcement by ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,4 +80,4 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "main.py" = ["D103"]
-"tests/**" = ["D101", "D102", "D103"]
+"tests/**" = ["D101", "D102", "D103", "D104", "D105"]


### PR DESCRIPTION
unit tests dont need mandatory docstrings enforcement by ruff